### PR TITLE
Fix workflows

### DIFF
--- a/ml/rl/test/gridworld/test_gridworld_ddpg.py
+++ b/ml/rl/test/gridworld/test_gridworld_ddpg.py
@@ -67,8 +67,8 @@ class TestGridworldContinuous(unittest.TestCase):
         critic_predictor = trainer.predictor(actor=False)
         evaluator.evaluate_critic(critic_predictor)
         for tdp in tdps:
-            tdp.rewards = tdp.rewards.flatten()
-            tdp.not_terminals = tdp.not_terminals.flatten()
+            tdp.rewards = tdp.rewards.reshape(-1, 1)
+            tdp.not_terminals = tdp.not_terminals.reshape(-1, 1)
             trainer.train(tdp)
 
         # Make sure actor predictor works

--- a/ml/rl/workflow/ddpg_workflow.py
+++ b/ml/rl/workflow/ddpg_workflow.py
@@ -87,6 +87,7 @@ def train_network(params):
 
     start_time = time.time()
     for epoch in range(params["epochs"]):
+        dataset.reset_iterator()
         for batch_idx in range(num_batches):
             report_training_status(batch_idx, num_batches, epoch, params["epochs"])
             batch = dataset.read_batch(batch_idx)

--- a/ml/rl/workflow/dqn_workflow.py
+++ b/ml/rl/workflow/dqn_workflow.py
@@ -118,6 +118,7 @@ def train_network(params):
 
     start_time = time.time()
     for epoch in range(int(params["epochs"])):
+        dataset.reset_iterator()
         for batch_idx in range(num_batches):
             report_training_status(batch_idx, num_batches, epoch, int(params["epochs"]))
             batch = dataset.read_batch(batch_idx)

--- a/ml/rl/workflow/parametric_dqn_workflow.py
+++ b/ml/rl/workflow/parametric_dqn_workflow.py
@@ -108,6 +108,7 @@ def train_network(params):
 
     start_time = time.time()
     for epoch in range(params["epochs"]):
+        dataset.reset_iterator()
         for batch_idx in range(num_batches):
             report_training_status(batch_idx, num_batches, epoch, params["epochs"])
             batch = dataset.read_batch(batch_idx)

--- a/ml/rl/workflow/training_data_reader.py
+++ b/ml/rl/workflow/training_data_reader.py
@@ -23,12 +23,16 @@ class JSONDataset:
         self.len = self.line_count()
         if self.read_data_in_chunks:
             # Do not read entire dataset into memory
-            self.data_iterator = pd.read_json(
-                self.path, lines=True, chunksize=self.batch_size
-            )
+            self.reset_iterator()
         else:
             # Read entire dataset into memory
             self.data = pd.read_json(self.path, lines=True)
+
+    def reset_iterator(self):
+        if self.read_data_in_chunks:
+            self.data_iterator = pd.read_json(
+                self.path, lines=True, chunksize=self.batch_size
+            )
 
     def _get_chunked_reading_setting(self):
         """FB internal is currently pinned to Pandas 0.20.3 which does


### PR DESCRIPTION
Last bits of fixes to get tests going. `reset_iterator()` is needed to avoid running out of data when training with multiple epochs.