### PR TITLE
Fix link markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Horizon is an open source end-to-end platform for applied reinforcement learning
 - Parametric-Action DQN
 - [Double DQN](https://arxiv.org/abs/1509.06461), [Dueling DQN](https://arxiv.org/abs/1511.06581), [Dueling Double DQN](https://arxiv.org/abs/1710.02298)
 - [DDPG](https://arxiv.org/abs/1509.02971) (DDPG)
-- [Soft Actor-Critic] (https://arxiv.org/abs/1801.01290) (SAC)
+- [Soft Actor-Critic](https://arxiv.org/abs/1801.01290) (SAC)
 
 #### Installation
 Horizon can be installed via. Docker or manually. Detailed instructions on how to install Horizon can be found [here](docs/installation.md).


### PR DESCRIPTION
Remove a space from the Soft Actor-Critic link markdown.