### PR TITLE
Fix DDPGTrainer changes for multiple GPUs

### DIFF
--- a/ml/rl/test/gridworld/test_gridworld_ddpg.py
+++ b/ml/rl/test/gridworld/test_gridworld_ddpg.py
@@ -71,6 +71,8 @@ class TestGridworldDdpg(GridworldTestBase):
             fl_init=parameters.shared_training.final_layer_init,
             state_dim=state_dim,
             action_dim=action_dim,
+            use_gpu=use_gpu,
+            use_all_avail_gpus=use_all_avail_gpus,
         )
 
         # Build Critic Network
@@ -81,6 +83,8 @@ class TestGridworldDdpg(GridworldTestBase):
             fl_init=parameters.shared_training.final_layer_init,
             state_dim=state_dim,
             action_dim=action_dim,
+            use_gpu=use_gpu,
+            use_all_avail_gpus=use_all_avail_gpus,
         )
 
         trainer = DDPGTrainer(

--- a/ml/rl/test/gym/run_gym.py
+++ b/ml/rl/test/gym/run_gym.py
@@ -776,6 +776,8 @@ def create_trainer(model_type, params, rl_parameters, use_gpu, env):
             fl_init=trainer_params.shared_training.final_layer_init,
             state_dim=state_dim,
             action_dim=action_dim,
+            use_gpu=use_gpu,
+            use_all_avail_gpus=False,
         )
 
         # Build Critic Network
@@ -786,6 +788,8 @@ def create_trainer(model_type, params, rl_parameters, use_gpu, env):
             fl_init=trainer_params.shared_training.final_layer_init,
             state_dim=state_dim,
             action_dim=action_dim,
+            use_gpu=use_gpu,
+            use_all_avail_gpus=False,
         )
 
         trainer = DDPGTrainer(

--- a/ml/rl/workflow/ddpg_workflow.py
+++ b/ml/rl/workflow/ddpg_workflow.py
@@ -71,6 +71,8 @@ class ContinuousWorkflow(BaseWorkflow):
             fl_init=model_params.shared_training.final_layer_init,
             state_dim=state_dim,
             action_dim=action_dim,
+            use_gpu=use_gpu,
+            use_all_avail_gpus=use_all_avail_gpus,
         )
 
         # Build Critic Network
@@ -81,6 +83,8 @@ class ContinuousWorkflow(BaseWorkflow):
             fl_init=model_params.shared_training.final_layer_init,
             state_dim=state_dim,
             action_dim=action_dim,
+            use_gpu=use_gpu,
+            use_all_avail_gpus=use_all_avail_gpus,
         )
 
         trainer = DDPGTrainer(


### PR DESCRIPTION
Summary: Pushing the multi-gpu `nn.DataParallel` wrapping to happen on the low level networks level versus the `ModelBase` so we can continue using `StateAction` named tuple types and retain the `ModelBase` interface.

Differential Revision: D15005795

