### PR TITLE
tensorboardX -> torch.utils.tensorboard

### DIFF
--- a/ml/rl/tensorboardX.py
+++ b/ml/rl/tensorboardX.py
@@ -22,7 +22,7 @@ import contextlib
 import logging
 from typing import Any, Dict, List
 
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 
 logger = logging.getLogger(__name__)

--- a/ml/rl/test/base/test_tensorboardX.py
+++ b/ml/rl/test/base/test_tensorboardX.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, call
 import torch
 from ml.rl.tensorboardX import SummaryWriterContext, summary_writer_context
 from ml.rl.test.base.horizon_test_base import HorizonTestBase
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 
 class TestSummaryWriterContext(HorizonTestBase):

--- a/ml/rl/training/loss_reporter.py
+++ b/ml/rl/training/loss_reporter.py
@@ -8,7 +8,6 @@ from typing import List, NamedTuple, Optional
 import numpy as np
 import torch
 from ml.rl.tensorboardX import SummaryWriterContext
-from tensorboardX import SummaryWriter
 
 
 logger = logging.getLogger(__name__)

--- a/ml/rl/workflow/dqn_workflow.py
+++ b/ml/rl/workflow/dqn_workflow.py
@@ -34,8 +34,8 @@ from ml.rl.workflow.helpers import (
 )
 from ml.rl.workflow.preprocess_handler import DiscreteDqnPreprocessHandler
 from ml.rl.workflow.transitional import create_dqn_trainer_from_params
-from tensorboardX import SummaryWriter
 from torch import multiprocessing
+from torch.utils.tensorboard import SummaryWriter
 
 
 logger = logging.getLogger(__name__)

--- a/ml/rl/workflow/parametric_dqn_workflow.py
+++ b/ml/rl/workflow/parametric_dqn_workflow.py
@@ -36,8 +36,8 @@ from ml.rl.workflow.preprocess_handler import (
     PreprocessHandler,
 )
 from ml.rl.workflow.transitional import create_parametric_dqn_trainer_from_params
-from tensorboardX import SummaryWriter
 from torch import multiprocessing
+from torch.utils.tensorboard import SummaryWriter
 
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pytest-xdist==1.24.0
 pytorch
 scipy==1.1.0
 tensorboard==1.14
-tensorboardX==1.6
 tensorflow==1.14
 thrift==0.10.0
 thrift-cpp==0.10.0


### PR DESCRIPTION
Summary: switching to use torch.utils.tensorboard instead of tensorboardX

Differential Revision: D17471644

