### PR TITLE
Fix preprocessor when the normalization type is DO_NOT_PREPROCESS

### DIFF
--- a/reagent/gym/tests/test_world_model.py
+++ b/reagent/gym/tests/test_world_model.py
@@ -393,7 +393,7 @@ class TestWorldModel(HorizonTestBase):
             config_path=os.path.join(curr_dir, config_path),
             use_gpu=False,
         )
-        TestWorldModel.verify_result(feature_importance, ["state3"])
+        TestWorldModel.verify_result(feature_importance, ["state1", "state3"])
         TestWorldModel.verify_result(feature_sensitivity, ["state3"])
         logger.info("MDNRNN feature test passes!")
 


### PR DESCRIPTION
Summary: When the normalization type is DO_NOT_PREPROCESS, we shouldn't clamp the output. We shouldn't check if the output is within `[MIN_FEATURE_VALUE, MAX_FEATURE_VALUE]` either.

Differential Revision: D23962184

