### PR TITLE
Deprecate PreprocessedTrainingBatch

### DIFF
--- a/reagent/evaluation/evaluation_data_page.py
+++ b/reagent/evaluation/evaluation_data_page.py
@@ -51,7 +51,7 @@ class EvaluationDataPage(NamedTuple):
     @classmethod
     def create_from_training_batch(
         cls,
-        tdb: rlt.PreprocessedTrainingBatch,
+        tdb: rlt.PreprocessedRankingInput,
         trainer: Trainer,
         reward_network: Optional[nn.Module] = None,
     ):
@@ -84,9 +84,7 @@ class EvaluationDataPage(NamedTuple):
                 metrics=tdb.extras.metrics,
             )
         else:
-            raise NotImplementedError(
-                f"training_input type: {type(tdb.training_input)}"
-            )
+            raise NotImplementedError(f"training_input type: {type(tdb)}")
 
     @classmethod
     # pyre-fixme[56]: Decorator `torch.no_grad(...)` could not be called, because

--- a/reagent/evaluation/reward_net_evaluator.py
+++ b/reagent/evaluation/reward_net_evaluator.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from reagent import types as rlt
 from reagent.training.reward_network_trainer import RewardNetTrainer
-from reagent.types import PreprocessedTrainingBatch
+from reagent.types import PreprocessedRankingInput
 
 
 logger = logging.getLogger(__name__)
@@ -27,18 +27,18 @@ class RewardNetEvaluator:
     # pyre-fixme[56]: Decorator `torch.no_grad(...)` could not be called, because
     #  its type `no_grad` is not callable.
     @torch.no_grad()
-    def evaluate(self, eval_tdp: PreprocessedTrainingBatch):
+    def evaluate(self, eval_tdp: PreprocessedRankingInput):
         reward_net = self.trainer.reward_net
         reward_net_prev_mode = reward_net.training
         reward_net.eval()
 
-        if isinstance(eval_tdp.training_input, rlt.PreprocessedRankingInput):
-            reward = eval_tdp.training_input.slate_reward
+        if isinstance(eval_tdp, rlt.PreprocessedRankingInput):
+            reward = eval_tdp.slate_reward
         else:
-            reward = eval_tdp.training_input.reward
+            reward = eval_tdp.reward
         assert reward is not None
 
-        pred_reward = reward_net(eval_tdp.training_input).predicted_reward
+        pred_reward = reward_net(eval_tdp).predicted_reward
         loss = self.trainer.loss_fn(pred_reward, reward)
         self.loss.append(loss.flatten().detach().cpu())
         self.rewards.append(reward.flatten().detach().cpu())

--- a/reagent/gym/types.py
+++ b/reagent/gym/types.py
@@ -106,7 +106,7 @@ ContinuousScorer = Callable[[Any], Any]
 Scorer = Union[DiscreteScorer, ContinuousScorer]
 
 # Transform ReplayBuffer's transition batch to trainer.train
-TrainerPreprocessor = Callable[[Any], rlt.PreprocessedTrainingBatch]
+TrainerPreprocessor = Callable[[Any], Any]
 
 
 """ Called after env.step(action)

--- a/reagent/test/evaluation/test_evaluation_data_page.py
+++ b/reagent/test/evaluation/test_evaluation_data_page.py
@@ -140,16 +140,14 @@ class TestEvaluationDataPage(unittest.TestCase):
             tgt_out_idx.flatten() - 2,
         ].reshape(batch_size, tgt_seq_len, candidate_dim)
 
-        ptb = rlt.PreprocessedTrainingBatch(
-            training_input=rlt.PreprocessedRankingInput(
-                state=rlt.FeatureData(float_features=torch.eye(state_dim)),
-                src_seq=rlt.FeatureData(float_features=src_seq),
-                tgt_out_seq=rlt.FeatureData(float_features=tgt_out_seq),
-                src_src_mask=torch.ones(batch_size, src_seq_len, src_seq_len),
-                tgt_out_idx=tgt_out_idx,
-                tgt_out_probs=torch.tensor([0.2, 0.5, 0.4]),
-                slate_reward=torch.tensor([4.0, 5.0, 7.0]),
-            ),
+        ptb = rlt.PreprocessedRankingInput(
+            state=rlt.FeatureData(float_features=torch.eye(state_dim)),
+            src_seq=rlt.FeatureData(float_features=src_seq),
+            tgt_out_seq=rlt.FeatureData(float_features=tgt_out_seq),
+            src_src_mask=torch.ones(batch_size, src_seq_len, src_seq_len),
+            tgt_out_idx=tgt_out_idx,
+            tgt_out_probs=torch.tensor([0.2, 0.5, 0.4]),
+            slate_reward=torch.tensor([4.0, 5.0, 7.0]),
             extras=rlt.ExtraData(
                 sequence_number=torch.tensor([0, 0, 0]),
                 mdp_id=np.array(["0", "1", "2"]),
@@ -157,7 +155,7 @@ class TestEvaluationDataPage(unittest.TestCase):
         )
 
         edp = EvaluationDataPage.create_from_tensors_seq2slate(
-            seq2slate_net, reward_net, ptb.training_input, eval_greedy=True
+            seq2slate_net, reward_net, ptb, eval_greedy=True
         )
         logger.info("---------- Start evaluating eval_greedy=True -----------------")
         doubly_robust_estimator = DoublyRobustEstimator()
@@ -207,7 +205,7 @@ class TestEvaluationDataPage(unittest.TestCase):
 
         logger.info("---------- Start evaluating eval_greedy=False -----------------")
         edp = EvaluationDataPage.create_from_tensors_seq2slate(
-            seq2slate_net, reward_net, ptb.training_input, eval_greedy=False
+            seq2slate_net, reward_net, ptb, eval_greedy=False
         )
         doubly_robust_estimator = DoublyRobustEstimator()
         _, inverse_propensity, _ = doubly_robust_estimator.estimate(edp)

--- a/reagent/test/evaluation/test_ope_integration.py
+++ b/reagent/test/evaluation/test_ope_integration.py
@@ -247,16 +247,14 @@ class TestOPEModuleAlgs(unittest.TestCase):
             tgt_out_idx.flatten() - 2,
         ].reshape(batch_size, tgt_seq_len, candidate_dim)
 
-        ptb = rlt.PreprocessedTrainingBatch(
-            training_input=rlt.PreprocessedRankingInput(
-                state=rlt.FeatureData(float_features=torch.eye(state_dim)),
-                src_seq=rlt.FeatureData(float_features=src_seq),
-                tgt_out_seq=rlt.FeatureData(float_features=tgt_out_seq),
-                src_src_mask=torch.ones(batch_size, src_seq_len, src_seq_len),
-                tgt_out_idx=tgt_out_idx,
-                tgt_out_probs=torch.tensor([0.2, 0.5, 0.4]),
-                slate_reward=torch.tensor([4.0, 5.0, 7.0]),
-            ),
+        ptb = rlt.PreprocessedRankingInput(
+            state=rlt.FeatureData(float_features=torch.eye(state_dim)),
+            src_seq=rlt.FeatureData(float_features=src_seq),
+            tgt_out_seq=rlt.FeatureData(float_features=tgt_out_seq),
+            src_src_mask=torch.ones(batch_size, src_seq_len, src_seq_len),
+            tgt_out_idx=tgt_out_idx,
+            tgt_out_probs=torch.tensor([0.2, 0.5, 0.4]),
+            slate_reward=torch.tensor([4.0, 5.0, 7.0]),
             extras=rlt.ExtraData(
                 sequence_number=torch.tensor([0, 0, 0]),
                 mdp_id=np.array(["0", "1", "2"]),
@@ -264,7 +262,7 @@ class TestOPEModuleAlgs(unittest.TestCase):
         )
 
         edp = EvaluationDataPage.create_from_tensors_seq2slate(
-            seq2slate_net, reward_net, ptb.training_input, eval_greedy=True
+            seq2slate_net, reward_net, ptb, eval_greedy=True
         )
         logger.info("---------- Start evaluating eval_greedy=True -----------------")
         doubly_robust_estimator = OPEstimatorAdapter(DoublyRobustEstimator())
@@ -313,7 +311,7 @@ class TestOPEModuleAlgs(unittest.TestCase):
 
         logger.info("---------- Start evaluating eval_greedy=False -----------------")
         edp = EvaluationDataPage.create_from_tensors_seq2slate(
-            seq2slate_net, reward_net, ptb.training_input, eval_greedy=False
+            seq2slate_net, reward_net, ptb, eval_greedy=False
         )
         doubly_robust_estimator = OPEstimatorAdapter(DoublyRobustEstimator())
         dm_estimator = OPEstimatorAdapter(DMEstimator())

--- a/reagent/test/ranking/test_seq2slate_trainer.py
+++ b/reagent/test/ranking/test_seq2slate_trainer.py
@@ -214,7 +214,7 @@ class TestSeq2SlateTrainer(unittest.TestCase):
             device,
         )
         for _ in range(policy_gradient_interval):
-            trainer.train(rlt.PreprocessedTrainingBatch(training_input=batch))
+            trainer.train(batch)
 
         # manual compute gradient
         torch.manual_seed(rank_seed)
@@ -300,7 +300,7 @@ class TestSeq2SlateTrainer(unittest.TestCase):
         )
 
         for _ in range(policy_gradient_interval):
-            trainer.train(rlt.PreprocessedTrainingBatch(training_input=batch))
+            trainer.train(batch)
 
         # manual compute gradient
         ranked_per_seq_log_probs = seq2slate_net_copy(
@@ -370,7 +370,7 @@ class TestSeq2SlateTrainer(unittest.TestCase):
         )
 
         for _ in range(policy_gradient_interval):
-            trainer.train(rlt.PreprocessedTrainingBatch(training_input=batch))
+            trainer.train(batch)
 
         # manual compute gradient
         ranked_per_seq_probs = torch.exp(

--- a/reagent/test/ranking/test_seq2slate_utils.py
+++ b/reagent/test/ranking/test_seq2slate_utils.py
@@ -327,7 +327,7 @@ def run_seq2slate_tsp(
                 batch = post_preprocess_batch(
                     learning_method, seq2slate_net, candidate_num, batch, device, e
                 )
-                trainer.train(rlt.PreprocessedTrainingBatch(training_input=batch))
+                trainer.train(batch)
 
         # evaluation
         best_test_reward = torch.full((batch_size,), 1e9).to(device)

--- a/reagent/training/ranking/seq2slate_attn_trainer.py
+++ b/reagent/training/ranking/seq2slate_attn_trainer.py
@@ -52,19 +52,17 @@ class Seq2SlatePairwiseAttnTrainer(Trainer):
         components = ["seq2slate_net"]
         return components
 
-    def train(self, training_batch: rlt.PreprocessedTrainingBatch):
-        assert type(training_batch) is rlt.PreprocessedTrainingBatch
-        training_input = training_batch.training_input
-        assert isinstance(training_input, rlt.PreprocessedRankingInput)
+    def train(self, training_batch: rlt.PreprocessedRankingInput):
+        assert type(training_batch) is rlt.PreprocessedRankingInput
 
         # shape: batch_size, tgt_seq_len
         encoder_scores = self.seq2slate_net(
-            training_input, mode=Seq2SlateMode.ENCODER_SCORE_MODE
+            training_batch, mode=Seq2SlateMode.ENCODER_SCORE_MODE
         ).encoder_scores
         assert encoder_scores.requires_grad
 
         loss = self.kl_loss(
-            self.log_softmax(encoder_scores), training_input.position_reward
+            self.log_softmax(encoder_scores), training_batch.position_reward
         )
         self.optimizer.zero_grad()
         loss.backward()

--- a/reagent/training/ranking/seq2slate_sim_trainer.py
+++ b/reagent/training/ranking/seq2slate_sim_trainer.py
@@ -202,13 +202,7 @@ class Seq2SlateSimulationTrainer(Trainer):
         )
         return on_policy_input
 
-    def train(self, training_batch: rlt.PreprocessedTrainingBatch):
-        assert type(training_batch) is rlt.PreprocessedTrainingBatch
-        training_input = training_batch.training_input
-        assert isinstance(training_input, rlt.PreprocessedRankingInput)
-        training_input = self._simulated_training_input(training_input)
-        return self.trainer.train(
-            rlt.PreprocessedTrainingBatch(
-                training_input=training_input, extras=training_batch.extras
-            )
-        )
+    def train(self, training_batch: rlt.PreprocessedRankingInput):
+        assert type(training_batch) is rlt.PreprocessedRankingInput
+        training_batch = self._simulated_training_input(training_batch)
+        return self.trainer.train(training_batch)

--- a/reagent/training/ranking/seq2slate_tf_trainer.py
+++ b/reagent/training/ranking/seq2slate_tf_trainer.py
@@ -52,21 +52,19 @@ class Seq2SlateTeacherForcingTrainer(Trainer):
         components = ["seq2slate_net"]
         return components
 
-    def train(self, training_batch: rlt.PreprocessedTrainingBatch):
-        assert type(training_batch) is rlt.PreprocessedTrainingBatch
-        training_input = training_batch.training_input
-        assert isinstance(training_input, rlt.PreprocessedRankingInput)
+    def train(self, training_batch: rlt.PreprocessedRankingInput):
+        assert type(training_batch) is rlt.PreprocessedRankingInput
         self.minibatch += 1
 
         log_probs = self.seq2slate_net(
-            training_input, mode=Seq2SlateMode.PER_SYMBOL_LOG_PROB_DIST_MODE
+            training_batch, mode=Seq2SlateMode.PER_SYMBOL_LOG_PROB_DIST_MODE
         ).log_probs
         assert log_probs.requires_grad
 
-        assert training_input.optim_tgt_out_idx is not None
+        assert training_batch.optim_tgt_out_idx is not None
         # pyre-fixme[6]: Expected `Tensor` for 1st param but got
         #  `Optional[torch.Tensor]`.
-        labels = self._transform_label(training_input.optim_tgt_out_idx)
+        labels = self._transform_label(training_batch.optim_tgt_out_idx)
         assert not labels.requires_grad
         loss = self.kl_div_loss(log_probs, labels)
 

--- a/reagent/training/reward_network_trainer.py
+++ b/reagent/training/reward_network_trainer.py
@@ -74,14 +74,13 @@ class RewardNetTrainer(Trainer):
         self.loss_fn = _get_loss_function(loss_type, reward_ignore_threshold)
         self.reward_ignore_threshold = reward_ignore_threshold
 
-    def train(self, training_batch: rlt.PreprocessedTrainingBatch):
-        training_input = training_batch.training_input
-        if isinstance(training_input, rlt.PreprocessedRankingInput):
-            target_reward = training_input.slate_reward
+    def train(self, training_batch: rlt.PreprocessedRankingInput):
+        if isinstance(training_batch, rlt.PreprocessedRankingInput):
+            target_reward = training_batch.slate_reward
         else:
-            target_reward = training_input.reward
+            target_reward = training_batch.reward
 
-        predicted_reward = self.reward_net(training_input).predicted_reward
+        predicted_reward = self.reward_net(training_batch).predicted_reward
         loss = self.loss_fn(predicted_reward, target_reward)
         self.opt.zero_grad()
         loss.backward()


### PR DESCRIPTION
Summary:
Use the class PreprocessedRankingInput to replace every occurrence of PreprocessedTrainingBatch.
In addition, move the extras field in PreprocessedTrainingBatchinto PreprocessedRankingInput.

Differential Revision: D25683974

