### PR TITLE
fix CircleCI test config for MAB

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -110,7 +110,6 @@ commands =
 
 [testenv:circleci_mab_unittest]
 extras =
-    mab
     test
 commands =
     pytest reagent/test/mab -n2


### PR DESCRIPTION
Summary: `mab` extra doesn't exist

Differential Revision: D31768958

