### PR TITLE
Fix the batch size issue cuased by recent OSS PyTorch Lightning changes

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -677,6 +677,7 @@ class BaseInput(TensorDataClass):
     not_terminal: torch.Tensor
 
     def __len__(self):
+        assert self.state.float_features.ndim == 2
         return self.state.float_features.size()[0]
 
     def batch_size(self):
@@ -929,7 +930,11 @@ class PolicyGradientInput(TensorDataClass):
         )
 
     def __len__(self):
+        assert self.action.ndim == 2
         return len(self.action)
+
+    def batch_size(self):
+        return len(self)
 
 
 @dataclass
@@ -947,6 +952,10 @@ class BanditRewardModelInput(TensorDataClass):
             reward=batch["reward"],
             action_prob=batch.get("action_probability", None),
         )
+
+    def batch_size(self):
+        assert self.state.float_features.ndim == 2
+        return self.state.float_features.size()[0]
 
 
 @dataclass
@@ -979,16 +988,6 @@ class MemoryNetworkInput(BaseInput):
             return self.state.float_features.size()[1]
         else:
             raise NotImplementedError()
-
-
-@dataclass
-class PreprocessedTrainingBatch(TensorDataClass):
-    training_input: Union[PreprocessedRankingInput]
-    # TODO: deplicate this and move into individual ones.
-    extras: ExtraData = field(default_factory=ExtraData)
-
-    def batch_size(self):
-        return self.training_input.state.float_features.size()[0]
 
 
 @dataclass

--- a/reagent/training/c51_trainer.py
+++ b/reagent/training/c51_trainer.py
@@ -181,7 +181,9 @@ class C51Trainer(RLTrainerMixin, ReAgentLightningModule):
                 model_values=all_q_values,
                 model_action_idxs=model_action_idxs,
             )
-            self.log("td_loss", loss, prog_bar=True)
+            self.log(
+                "td_loss", loss, prog_bar=True, batch_size=training_batch.batch_size()
+            )
 
         yield loss
         result = self.soft_update_result()

--- a/reagent/training/discrete_crr_trainer.py
+++ b/reagent/training/discrete_crr_trainer.py
@@ -323,7 +323,9 @@ class DiscreteCRRTrainer(DQNTrainerBaseLightning):
         q1_loss = self.compute_td_loss(self.q1_network, state, action, target_q_values)
 
         # Show td_loss on the progress bar and in tensorboard graphs:
-        self.log("td_loss", q1_loss, prog_bar=True)
+        self.log(
+            "td_loss", q1_loss, prog_bar=True, batch_size=training_batch.batch_size()
+        )
         yield q1_loss
 
         if self.q2_network:
@@ -348,8 +350,18 @@ class DiscreteCRRTrainer(DQNTrainerBaseLightning):
         # )
 
         # Show actor_loss on the progress bar and also in Tensorboard graphs
-        self.log("actor_loss_without_reg", actor_loss_without_reg, prog_bar=True)
-        self.log("actor_loss", actor_loss, prog_bar=True)
+        self.log(
+            "actor_loss_without_reg",
+            actor_loss_without_reg,
+            prog_bar=True,
+            batch_size=training_batch.batch_size(),
+        )
+        self.log(
+            "actor_loss",
+            actor_loss,
+            prog_bar=True,
+            batch_size=training_batch.batch_size(),
+        )
         yield actor_loss
 
         yield from self._calculate_cpes(
@@ -426,8 +438,12 @@ class DiscreteCRRTrainer(DQNTrainerBaseLightning):
         )
         td_loss = self.compute_td_loss(self.q1_network, state, action, target_q_values)
 
-        self.log("eval_actor_loss_without_reg", actor_loss_without_reg)
-        self.log("eval_actor_loss", actor_loss)
-        self.log("eval_td_loss", td_loss)
+        self.log(
+            "eval_actor_loss_without_reg",
+            actor_loss_without_reg,
+            batch_size=batch.batch_size(),
+        )
+        self.log("eval_actor_loss", actor_loss, batch_size=batch.batch_size())
+        self.log("eval_td_loss", td_loss, batch_size=batch.batch_size())
 
         return super().validation_step(batch, batch_idx)

--- a/reagent/training/dqn_trainer.py
+++ b/reagent/training/dqn_trainer.py
@@ -303,5 +303,5 @@ class DQNTrainer(DQNTrainerBaseLightning):
         discount_tensor = self.compute_discount_tensor(batch, rewards)
         td_loss = self.compute_td_loss(batch, rewards, discount_tensor)
         # Show eval_td_loss in a tensorboard graph
-        self.log("eval_td_loss", td_loss)
+        self.log("eval_td_loss", td_loss, batch_size=batch.batch_size())
         return super().validation_step(batch, batch_idx)

--- a/reagent/training/slate_q_trainer.py
+++ b/reagent/training/slate_q_trainer.py
@@ -269,5 +269,7 @@ class SlateQTrainer(RLTrainerMixin, ReAgentLightningModule):
 
         # Use the soft update rule to update the target networks
         result = self.soft_update_result()
-        self.log("td_loss", value_loss, prog_bar=True)
+        self.log(
+            "td_loss", value_loss, prog_bar=True, batch_size=training_batch.batch_size()
+        )
         yield result

--- a/reagent/training/td3_trainer.py
+++ b/reagent/training/td3_trainer.py
@@ -161,7 +161,9 @@ class TD3Trainer(RLTrainerMixin, ReAgentLightningModule):
                 next_q_value=next_q_value,
                 target_q_value=target_q_value,
             )
-        self.log("td_loss", q1_loss, prog_bar=True)
+        self.log(
+            "td_loss", q1_loss, prog_bar=True, batch_size=training_batch.batch_size()
+        )
         yield q1_loss
 
         if self.q2_network:

--- a/reagent/training/world_model/mdnrnn_trainer.py
+++ b/reagent/training/world_model/mdnrnn_trainer.py
@@ -59,7 +59,9 @@ class MDNRNNTrainer(ReAgentLightningModule):
         loss = losses["loss"]
         # TODO: Must setup (or mock) trainer and a LoggerConnector to call self.log()!
         if self.trainer is not None and self.trainer.logger is not None:
-            self.log("td_loss", loss, prog_bar=True)
+            self.log(
+                "td_loss", loss, prog_bar=True, batch_size=training_batch.batch_size()
+            )
         yield loss
 
     def validation_step(  # pyre-ignore inconsistent override because lightning doesn't use types
@@ -80,7 +82,7 @@ class MDNRNNTrainer(ReAgentLightningModule):
         )
 
         loss = losses["loss"]
-        self.log("td_loss", loss, prog_bar=True)
+        self.log("td_loss", loss, prog_bar=True, batch_size=training_batch.batch_size())
         return loss
 
     def test_step(  # pyre-ignore inconsistent override because lightning doesn't use types
@@ -101,7 +103,7 @@ class MDNRNNTrainer(ReAgentLightningModule):
         )
 
         loss = losses["loss"]
-        self.log("td_loss", loss, prog_bar=True)
+        self.log("td_loss", loss, prog_bar=True, batch_size=training_batch.batch_size())
         return loss
 
     def get_loss(


### PR DESCRIPTION
Summary:
Recent changes in PyTorch Lightning doesn't set batch_size to 1 any more if for customized types. Therefore, we need to explicitly pass in the correct batch size when using self.log. Otherwise, the following errors would occur in OSS tests:

https://app.circleci.com/pipelines/github/facebookresearch/ReAgent/2211/workflows/c4eb86dc-cbb9-46d4-849a-aeb966be50e2/jobs/19599

https://app.circleci.com/pipelines/github/facebookresearch/ReAgent/2211/workflows/c4eb86dc-cbb9-46d4-849a-aeb966be50e2/jobs/19591

Differential Revision: D33311293

