### PR TITLE
Add foreach flag to reagent optimizer configs

### DIFF
--- a/reagent/optimizer/uninferrable_optimizers.py
+++ b/reagent/optimizer/uninferrable_optimizers.py
@@ -25,6 +25,7 @@ class Adam(OptimizerConfig):
     weight_decay: float = 0
     amsgrad: bool = False
     maximize: bool = False
+    foreach: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -35,6 +36,7 @@ class NAdam(OptimizerConfig):
     weight_decay: float = 0
     momentum_decay: float = 4e-3
     maximize: bool = False
+    foreach: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -44,6 +46,7 @@ class RAdam(OptimizerConfig):
     eps: float = 1e-08
     weight_decay: float = 0
     maximize: bool = False
+    foreach: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -54,6 +57,7 @@ class SGD(OptimizerConfig):
     dampening: float = 0.0
     nesterov: bool = False
     maximize: bool = False
+    foreach: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -64,6 +68,7 @@ class AdamW(OptimizerConfig):
     weight_decay: float = 0.01
     amsgrad: bool = False
     maximize: bool = False
+    foreach: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -81,6 +86,7 @@ class Adamax(OptimizerConfig):
     eps: float = 1e-08
     weight_decay: float = 0
     maximize: bool = False
+    foreach: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -101,3 +107,4 @@ class Rprop(OptimizerConfig):
     etas: Tuple[float, float] = (0.5, 1.2)
     step_sizes: Tuple[float, float] = (1e-06, 50)
     maximize: bool = False
+    foreach: Optional[bool] = None


### PR DESCRIPTION
Summary:
A new foreach flag is being added to the optimizers to indicate whether foreach logic or single tensor logic is used (see D33767870).

This causes reagent tests to fail such as https://www.internalfb.com/intern/testinfra/diagnostics/7318349469673867.281475021413633.1644559942/

The issue arises from this line https://fburl.com/code/lroy3a2p where the value for foreach cannot be found in `getattr(self, k)`.

This PR adds the foreach flag to `uninferrable_optimizers.py` to address this (Note that we do not add this flag to `LBFGS` and `SparseAdam` as they do not support this option)

Differential Revision: D34216723

