### PR TITLE
expose final activation argument for critic Q-network

### DIFF
--- a/reagent/models/critic.py
+++ b/reagent/models/critic.py
@@ -19,6 +19,7 @@ class FullyConnectedCritic(ModelBase):
         use_batch_norm: bool = False,
         use_layer_norm: bool = False,
         output_dim: int = 1,
+        final_activation: str = "linear",  # most of the time "linear" is the right final activation to use!
     ) -> None:
         super().__init__()
         assert state_dim > 0, "state_dim must be > 0, got {}".format(state_dim)
@@ -32,7 +33,7 @@ class FullyConnectedCritic(ModelBase):
         )
         self.fc = FullyConnectedNetwork(
             [state_dim + action_dim] + sizes + [output_dim],
-            activations + ["linear"],
+            activations + [final_activation],
             use_batch_norm=use_batch_norm,
             use_layer_norm=use_layer_norm,
         )

--- a/reagent/models/fully_connected_network.py
+++ b/reagent/models/fully_connected_network.py
@@ -26,6 +26,7 @@ ACTIVATION_MAP = {
     "leaky_relu": nn.LeakyReLU,
     "linear": nn.Identity,
     "sigmoid": nn.Sigmoid,
+    "softplus": nn.Softplus,
 }
 
 

--- a/reagent/net_builder/parametric_dqn/fully_connected.py
+++ b/reagent/net_builder/parametric_dqn/fully_connected.py
@@ -19,6 +19,7 @@ class FullyConnected(ParametricDQNNetBuilder):
     activations: List[str] = field(default_factory=lambda: ["relu", "relu"])
     use_batch_norm: bool = False
     use_layer_norm: bool = False
+    final_activation: str = "linear"
 
     def __post_init_post_parse__(self) -> None:
         super().__init__()
@@ -47,4 +48,5 @@ class FullyConnected(ParametricDQNNetBuilder):
             use_batch_norm=self.use_batch_norm,
             use_layer_norm=self.use_layer_norm,
             output_dim=output_dim,
+            final_activation=self.final_activation,
         )


### PR DESCRIPTION
Summary:
Instead of always using a linear output activation, I want to specify which activation to use.
I want to try this with positive activation functions (e.g. relu) because I know that my Q-values have to be positive (all rewards are non-negative)

Differential Revision: D36744360

